### PR TITLE
do not block on a single message

### DIFF
--- a/lib/PubNub/PubSub.pm
+++ b/lib/PubNub/PubSub.pm
@@ -36,7 +36,7 @@ sub __ua {
     $ua->inactivity_timeout($self->{timeout});
     $ua->proxy->detect; # env proxy
     $ua->cookie_jar(0);
-    $ua->max_connections(1);
+    $ua->max_connections(100);
     $self->{ua} = $ua;
 
     return $ua;


### PR DESCRIPTION
This patch prevents module from blocking on a single message, otherwise it's just too slow, but this also introduces a problem -- now there's no any guaranty that messages will be received by pubnub in a same order in which they were published. This problem should be fixed separately. It seems Mojo::UserAgent doesn't support pipelining...
