### PR TITLE
Prevents deep recursion in the event of connection failure

### DIFF
--- a/lib/PubNub/PubSub.pm
+++ b/lib/PubNub/PubSub.pm
@@ -102,6 +102,10 @@ sub subscribe {
     my $tx = $ua->get($self->{web_host} . "/subscribe/$sub_key/$channel/0/$timetoken");
     unless ($tx->success) {
         # for example $tx->error->{message} =~ /Inactivity timeout/
+
+        # This is not a traditional goto. Instead it exits this function 
+        # and re-enters with @ as params.
+        #
         # see goto docs, this is basically a method call which exits the current
         # function first.  So no extra call stack depth.
         @_ = ($self, %params, timetoken => $timetoken);


### PR DESCRIPTION
The code isn't as readable as I like, but this is the only way I can seem to eliminate deep recursion if there is a connection failure.  This eliminates the extra call stack layer when we need to reconnect using `goto &func` but this requires setting up @_ manually above.
