### PR TITLE
Fix memleak in PubNub::PubSub::subscribe()

### DIFF
--- a/lib/PubNub/PubSub.pm
+++ b/lib/PubNub/PubSub.pm
@@ -120,7 +120,8 @@ sub subscribe { ## no critic (RequireArgUnpacking)
     return unless $rtn;
 
     $timetoken = $json->[1];
-    return $self->subscribe(%params, timetoken => $timetoken);
+    @_ = ($self, %params, timetoken => $timetoken);
+    goto &subscribe;
 }
 
 sub subscribe_multi { ## no critic (RequireArgUnpacking)


### PR DESCRIPTION
Fix the memleak by setting @_ and using goto instead of recursively
calling $self->subscribe(). This same technique is already used
elsewhere in the same subroutine.

Resolves GitHub issue #21.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>