### PR TITLE
Use Mojo::UserAgent::CookieJar behavior from Mojolicious >= 6.20

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,8 +2,12 @@ Revision history for PubNub-PubSub
 
 {{$NEXT}}
 
-1.0.1     2017-02-20 06:36:08+00:00 UTC
-  switch to dzil
+1.0.2  2019-01-05 23:41:19+00:00 UTC
+       - use Mojo::UserAgent::CookieJar behavior from Mojolicious >= 6.20 and bump dependency
+       - add simple testcase for subscribe method
+
+1.0.1  2017-02-20 06:36:08+00:00 UTC
+       - switch to dzil
   
 1.0.0
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ my %WriteMakefileArgs = (
   "MIN_PERL_VERSION" => "5.014000",
   "NAME" => "PubNub::PubSub",
   "PREREQ_PM" => {
-    "Mojolicious" => "5.40"
+    "Mojolicious" => "6.20"
   },
   "TEST_REQUIRES" => {
     "ExtUtils::MakeMaker" => 0,
@@ -42,7 +42,7 @@ my %FallbackPrereqs = (
   "File::Spec" => 0,
   "IO::Handle" => 0,
   "IPC::Open3" => 0,
-  "Mojolicious" => "5.40",
+  "Mojolicious" => "6.20",
   "Test::CheckDeps" => "0.010",
   "Test::More" => "0.96"
 );

--- a/lib/PubNub/PubSub.pm
+++ b/lib/PubNub/PubSub.pm
@@ -10,7 +10,7 @@ use Mojo::Util qw/url_escape/;
 
 use PubNub::PubSub::Message;
 
-our $VERSION = '1.0.1';
+our $VERSION = '1.0.2';
 
 sub new { ## no critic (RequireArgUnpacking)
     my $class = shift;
@@ -36,7 +36,7 @@ sub __ua {
     $ua->max_redirects(3);
     $ua->inactivity_timeout($self->{timeout});
     $ua->proxy->detect; # env proxy
-    $ua->cookie_jar(0);
+    $ua->cookie_jar->ignore(sub { 1 });
     $ua->max_connections(100);
     $self->{ua} = $ua;
 

--- a/t/subscribe.t
+++ b/t/subscribe.t
@@ -1,0 +1,27 @@
+use strict;
+use Test::More;
+use PubNub::PubSub;
+
+# not 100% deterministic e.g. on a very slow system, but $pubnub->subscribe should block forever if it's working, and the eval should quickly exit if not.
+# this is intended to catch cases like: Can't locate object method "prepare" via package "0" (perhaps you forgot to load "0"?) at /usr/share/perl5/Mojo/UserAgent.pm line 322
+
+$SIG{ALRM} = sub { die('ok') };
+
+eval {
+	my $pubnub = PubNub::PubSub->new(
+		host => 'test.invalid', # iana reserved
+		timeout => 1,
+	);
+
+	alarm(1);
+
+	my $result = $pubnub->subscribe(
+		channel => 'foo',
+		sub_key => 'bar',
+		callback => sub { return(0); },
+	);
+};
+
+like $@, qr/^ok /;
+
+done_testing;


### PR DESCRIPTION
In the past several years, Mojo::UserAgent::CookieJar has changed the
method used to disable it several times. With Mojolicious >= 5.45, the
previous $ua->cookie_jar(0) caused an error like:

   Can't locate object method "prepare" via package "0"

At that point, the way to disable it was changed to:
   $ua->cookie_jar->extracting(0).

With Mojolicious 6.0, the behavior changed yet again - it became:
   $ua->cookie_jar->collecting(0);

Finally, it has stabilized since 6.20 and until current (8.12) to:
   $ua->cookie_jar->ignore(sub { 1 });

Rather than add something like conditionals for $Mojolicious::VERSION
and support every deprecated method, this commit just changes all the
dependencies for Mojolicious to >= 6.20 and uses that behavior.

Due to the potentially breaking changes for those on older versions of
Mojolicious, the version number of the module has been bumped to 1.0.2.

This also includes a new test, subscribe.t, which attempts to make a
subscription to test.invalid and catches any errors in an eval block. An
alarm() and associated handler are used to leave the ->subscribe loop. I
wasn't sure if it'd be suitable for Windows due to the emulated SIGALRM,
but it passes there as well.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>